### PR TITLE
Computing imagestream size

### DIFF
--- a/build/report.py
+++ b/build/report.py
@@ -53,6 +53,19 @@ def getObjects(type, namespace='default'):
   return []
 #end
 
+def getImageStreamSize(namespace='default'):
+  oc = local["oc"]
+  imagestreams = json.loads(oc('get', 'imagestreams', '-n', namespace, '-o', 'json'))
+  print('PRINTING IMAGE STREAMS')
+
+  for imagestream in imagestreams['items']:
+    for imagestreamTag in imagestream['status']['tags']:
+      for imagestreamImage in imagestreamTag['items']:
+        print(imagestreamImage['image'])
+    
+
+#end
+
 def hpaCheck(workloadData):
   requiredScaleTargetRef = {'kind': workloadData['kind'], 'name': workloadData['metadata']['name']}
   retval = {'status': 'fail', 'text': "unable to find an HPA with the following scaleTargetRef:\n" + yaml.dump(requiredScaleTargetRef)}
@@ -107,7 +120,7 @@ def pdbCheck(workloadData):
 def writeReport(filename, results, namespace, checksInfo, clusterName, podsWithFailedChecks):
   workloadNames = results[next(iter(results))].keys()
   file = open(filename, 'w')
-
+  getImageStreamSize(namespace)
   env = Environment(
     autoescape=select_autoescape(),
     loader=FileSystemLoader(path.join(path.dirname(__file__), 'templates'))

--- a/build/report.py
+++ b/build/report.py
@@ -65,9 +65,8 @@ def getImageStreamSize(namespace='default'):
       for imagestreamTagItem in imagestreamTag['items']:
         image = imagestreamTagItem['image']
         imagestreamImages = json.loads(oc('get', f'--raw=/apis/image.openshift.io/v1/namespaces/{namespace}/imagestreamimages/{name}@{image}'))
-        streamsize = float(imagestreamImages['image']['dockerImageMetadata']['Size'])
-        totalSize += streamsize
-        logging.info('Imagestream: ' + name + '.  Size: ' + str(streamsize / 1000000) + ' MB')
+        for imageLayer in imagestreamImages['image']['dockerImageLayers']:
+          totalSize += float(imageLayer['size'])
 
   logging.info('TOTAL IMAGESTREAM SIZE: ' + str(totalSize / 1000000) + ' MB.')
   return totalSize

--- a/build/report.py
+++ b/build/report.py
@@ -70,6 +70,7 @@ def getImageStreamSize(namespace='default'):
         logging.info('Imagestream: ' + name + '.  Size: ' + str(streamsize / 1000000) + ' MB')
 
   logging.info('TOTAL IMAGESTREAM SIZE: ' + str(totalSize / 1000000) + ' MB.')
+  return totalSize
 
 #end
 
@@ -127,7 +128,7 @@ def pdbCheck(workloadData):
 def writeReport(filename, results, namespace, checksInfo, clusterName, podsWithFailedChecks):
   workloadNames = results[next(iter(results))].keys()
   file = open(filename, 'w')
-  getImageStreamSize(namespace)
+  imagestreamSize = getImageStreamSize(namespace)
   env = Environment(
     autoescape=select_autoescape(),
     loader=FileSystemLoader(path.join(path.dirname(__file__), 'templates'))
@@ -141,7 +142,8 @@ def writeReport(filename, results, namespace, checksInfo, clusterName, podsWithF
     results = results,
     checksInfo = checksInfo,
     podsWithFailedChecks = podsWithFailedChecks,
-    imagestreams = getObjects('imagestreams', namespace)
+    imagestreams = getObjects('imagestreams', namespace),
+    imagestreamSize = str(round(float(imagestreamSize / 1000000), 2))
   ))
   file.close()
 #end

--- a/build/report.py
+++ b/build/report.py
@@ -57,6 +57,7 @@ def getImageStreamSize(namespace='default'):
   totalSize = 0
   oc = local["oc"]
   imagestreams = json.loads(oc('get', 'imagestreams', '-n', namespace, '-o', 'json'))
+  logging.info("Number of image streams: " + str(len(imagestreams['items'])))
 
   for imagestream in imagestreams['items']:
     name = imagestream['metadata']['name']
@@ -64,13 +65,12 @@ def getImageStreamSize(namespace='default'):
       for imagestreamTagItem in imagestreamTag['items']:
         image = imagestreamTagItem['image']
         imagestreamImages = json.loads(oc('get', f'--raw=/apis/image.openshift.io/v1/namespaces/{namespace}/imagestreamimages/{name}@{image}'))
-        for imageLayer in imagestreamImages['image']['dockerImageLayers']:
-          totalSize += float(imageLayer['size'])
+        streamsize = float(imagestreamImages['image']['dockerImageMetadata']['Size'])
+        totalSize += streamsize
+        logging.info('Imagestream: ' + name + '.  Size: ' + str(streamsize / 1000000) + ' MB')
 
-  print('TOTAL SIZE: ' + str(totalSize / 1000000) + ' MB, over ' + str(len(getObjects('imagestreams', namespace))) + ' imagestreams.')
+  logging.info('TOTAL IMAGESTREAM SIZE: ' + str(totalSize / 1000000) + ' MB.')
 
-
-# ISTJSON=$(oc get --raw="/apis/image.openshift.io/v1/namespaces/${NS}/imagestreamimages/${IMAGESTREAM}@${IMAGE}")
 #end
 
 def hpaCheck(workloadData):

--- a/build/static/style.css
+++ b/build/static/style.css
@@ -46,7 +46,6 @@ td {
 }
 #quick-links {
   margin-bottom: 20px;
-  margin-left: 16px;
 }
 #quick-links a {
   margin-left: 4px;

--- a/build/templates/reportTemplate.html.j2
+++ b/build/templates/reportTemplate.html.j2
@@ -83,14 +83,16 @@
             <hr/>
             <h3>Details</h3>
             <div id="imagestream-info">
+               <h4>Imagestreams</h4>
                There {{ 'is' if imagestreams|length == 1 else 'are'}} {{ imagestreams|length }} 
-               imagestream{{'' if imagestreams|length == 1 else 's'}} running in namespace {{ namespace }}
+               imagestream{{'' if imagestreams|length == 1 else 's'}} running in namespace {{ namespace }} <p/>
+               Total size of imagestreams: {{ imagestreamSize }} MB
             </div>
             <div id="quick-links">
             {% if podsWithFailedChecks|length == 0 %}
                Hurray! All pods have passed all their status checks!
             {% else %}
-               Jump to pods with errors or warnings: 
+               <h4>Jump to pods with errors or warnings:</h4>
                {% for podWithFailedCheck in podsWithFailedChecks %}
                   <a href="#{{ podWithFailedCheck }}">{{ podWithFailedCheck }} </a>
                {% endfor %}


### PR DESCRIPTION
Context:
I'm not an OpenShift expert, so if anyone tells you anything different from any of this, they probably have a good point.

As you may be aware, applications on the OpenShift platform are based on a Docker image, which we use as a template, supplying parameter values for various configuration points, like the namespace used, and that kind of thing. So an OpenShift namespace (something like a1b2c3-tools, or whatever) streams the image to provide the code for an application, hence the namespace will be using "imagesteams". 
OK, so one source of frustration that the service boffins have is that various teams we serve are sometimes not cleaning up these imagestreams correctly in their environments, so they end up with lots and lots of imagestreams taking up lots and lots of space, so the report now includes information on how many imagestreams are used, and how much space they are taking up. At least that's the problem as I understand it.
While there are some very direct ways of querying OpenShift for this info, it requires cluster level admin privileges, which we've had to maneuver around with calls that require lower level privilege, and then drill down for that information, which is what you will see when you look at the crux of this PR, the getImagestreamSize method, or routine, or whatever python calls these def blocks.
Other than that, there's some styling stuff, and changes to the jinja2 template that we use to generate the HTML. All that stuff is fairly What You See Is What You Get, so I'm not all that concerned about it, but please take a glance and see if you can think of any way it could be improved.