### PR TITLE
Jenkins pod checks

### DIFF
--- a/build/report.py
+++ b/build/report.py
@@ -98,7 +98,6 @@ def checkForJenkins():
         'memReqMeestBP': compareValuesForBestPractice(podResources['requests']['memory'],  '512m')
       }
       podsWithJenkins.append(jenkinsPod)   
-      print(jenkinsPod)
   return podsWithJenkins
 #end
 
@@ -183,8 +182,6 @@ def writeReport(filename, results, namespace, checksInfo, clusterName, podsWithF
   if '-tools' in namespace:
     jenkinsPods = checkForJenkins()
 
-  if "-tools" in namespace:
-    logging.info("This appears to be a -tools namespace")
     #check for Jenkins in tools namespace
   env = Environment(
     autoescape=select_autoescape(),

--- a/build/report.py
+++ b/build/report.py
@@ -117,7 +117,7 @@ def compareValuesForBestPractice(val, recommended, lower = -1):
     if  'gb' in str.lower(recommended):
       recommendedAsNumber *= 1000
 
-    return val  < recommended and val > lower
+    return val <= recommended and val >= lower
   
   else:
     return str.lower(val) == str.lower(recommended)

--- a/build/report.py
+++ b/build/report.py
@@ -1,3 +1,4 @@
+
 import json
 from os import path
 import sys
@@ -88,13 +89,39 @@ def checkForJenkins():
       jenkinsPod  = {
         'name': pod,
         'cpuLimit': podResources['limits']['cpu'],
+        'cpuLimitMeetsBP':  compareValuesForBestPractice(podResources['limits']['cpu'], '1000m'),
         'memoryLimit': podResources['limits']['memory'],
+        'memLimitMeetsBP': compareValuesForBestPractice(podResources['limits']['memory'], '2Gb', '1Gb'),
         'cpuRequest': podResources['requests']['cpu'],
-        'memoryRequest': podResources['requests']['memory']
+        'cpuReqMeetsBP': compareValuesForBestPractice(podResources['requests']['cpu'], '100m'),
+        'memoryRequest': podResources['requests']['memory'],
+        'memReqMeestBP': compareValuesForBestPractice(podResources['requests']['memory'],  '512m')
       }
       podsWithJenkins.append(jenkinsPod)   
-
+      print(jenkinsPod)
   return podsWithJenkins
+#end
+
+def compareValuesForBestPractice(val, recommended, lower = -1):
+  lowerAsNumber = -1
+  if lower != -1:
+    numeric_filter = filter(str.isdigit, lower)
+    lowerAsNumber = int("".join(numeric_filter))
+    if  'gb' in str.lower(lower):
+      lowerAsNumber *= 1000
+    numeric_filter = filter(str.isdigit, val)
+    valAsNumber = int("".join(numeric_filter))
+    if  'gb' in str.lower(val):
+      valAsNumber *= 1000
+    numeric_filter = filter(str.isdigit, recommended)
+    recommendedAsNumber = int("".join(numeric_filter))
+    if  'gb' in str.lower(recommended):
+      recommendedAsNumber *= 1000
+
+    return val  < recommended and val > lower
+  
+  else:
+    return str.lower(val) == str.lower(recommended)
 #end
 
 def hpaCheck(workloadData):

--- a/build/static/style.css
+++ b/build/static/style.css
@@ -51,5 +51,8 @@ td {
   margin-left: 4px;
 }
 #jenkins-warning{
-  color: #D8292F
+  color: #D8292F;
+}
+#jenkins-best-practices{
+  margin-bottom: 8px;
 }

--- a/build/static/style.css
+++ b/build/static/style.css
@@ -50,3 +50,6 @@ td {
 #quick-links a {
   margin-left: 4px;
 }
+#jenkins-warning{
+  color: #D8292F
+}

--- a/build/templates/reportTemplate.html.j2
+++ b/build/templates/reportTemplate.html.j2
@@ -83,16 +83,18 @@
             <hr/>
             <h3>Details</h3>
             {% if jenkinsPods|length > 0 %}
-               <h4>Jenkins Pods</h4>
-                It looks like one or more Jenkins instances has been found in your tools namespace. <strong>Use of Jenkins is highly discouraged on the Platform due to
-                its high resource consumption.</strong> Please consider switching to other modern and more secure 
-                <a href="https://developer.gov.bc.ca/CICD-with-Pipeline-Automation" target="_blank">automation technologies available on the
-               Platform..</a>
-               <p/><p/>
-               Pods: 
-               {% for pod in   jenkinsPods %}
-                  {{ pod }}
-               {% endfor %}
+               <div id="jenkins-warning">
+                  <h4>Jenkins Pods</h4>
+                  It looks like one or more Jenkins instances has been found in your tools namespace. <strong>Use of Jenkins is highly discouraged on the Platform due to
+                  its high resource consumption.</strong> Please consider switching to other modern and more secure 
+                  <a href="https://developer.gov.bc.ca/CICD-with-Pipeline-Automation" target="_blank">automation technologies available on the
+                  Platform..</a>
+                  <p/><p/>
+                  Pods: 
+                  {% for pod in   jenkinsPods %}
+                     {{ pod }}
+                  {% endfor %}
+               </div>
             {% endif %}
             <div id="imagestream-info">
                <h4>Imagestreams</h4>

--- a/build/templates/reportTemplate.html.j2
+++ b/build/templates/reportTemplate.html.j2
@@ -91,32 +91,32 @@
                   Platform..</a>
                   <p/><p/>
                </div>
+               <div id=jenkins-best-practices>
+                  Your Jenkins instance(s) should be configured to match the resource settings recommended in the 
+                  <a href="https://developer.gov.bc.ca/Resource-Tuning-Recommendations#recommended-configuration"  target="_blank">Jenkins Resource Configuration 
+                  Best Practices</a>. Please refer to this <a href="https://www.youtube.com/watch?v=npMbAtJZSO0" target="_blank">how-to video</a> for step by step instructions for updating the Jenkins resource settings.
+               </div>
                Pods: 
                {% for pod in   jenkinsPods %}
                   <h4>Pod: {{ pod['name'] }}</h4>
                   <table class="table-bordered" id="{{ workloadName }}">
                      <tr>
                         <td>
-                           Config point
+                           <h4>Config Setting</h4>
                         </td>
                         <td>
-                           Allocation
+                           <h4>Allocation</h4>
                         </td>
                         <td>
-                           Recommended
+                           <h4>Recommended</h4>
                         </td>
                         <td>
-                           Meets best pratices?
-                        </td>
-                     </tr>
-                     <tr>
-                        <td>
-                           Limits
+                           <h4>Meets best pratices?</h4>
                         </td>
                      </tr>
                      <tr>
                         <td>
-                           CPU 
+                           CPU Limit
                         </td>
                         <td>
                            {{ pod['cpuLimit'] }}
@@ -140,7 +140,7 @@
                      </tr>
                      <tr>
                         <td>
-                           memory 
+                           Memory Limit
                         </td>
                         <td>
                            {{ pod['memoryLimit'] }}
@@ -164,12 +164,7 @@
                      </tr>
                      <tr>
                         <td>
-                           Requests
-                        </td>
-                     </tr>
-                     <tr>
-                        <td>
-                           CPU 
+                           CPU Request
                         </td>
                         <td>
                            {{ pod['cpuRequest'] }}
@@ -193,7 +188,7 @@
                      </tr>
                      <tr>
                         <td>
-                           memory 
+                           Memory Request
                         </td>
                         <td>
                            {{ pod['memoryRequest'] }}
@@ -216,6 +211,7 @@
                         </td>
                      </tr>
                   </table>
+                  <p/>
                {% endfor %}
             {% endif %}
             <div id="imagestream-info">

--- a/build/templates/reportTemplate.html.j2
+++ b/build/templates/reportTemplate.html.j2
@@ -96,9 +96,9 @@
                   <a href="https://developer.gov.bc.ca/Resource-Tuning-Recommendations#recommended-configuration"  target="_blank">Jenkins Resource Configuration 
                   Best Practices</a>. Please refer to this <a href="https://www.youtube.com/watch?v=npMbAtJZSO0" target="_blank">how-to video</a> for step by step instructions for updating the Jenkins resource settings.
                </div>
-               Pods: 
-               {% for pod in   jenkinsPods %}
-                  <h4>Pod: {{ pod['name'] }}</h4>
+               <h4>Pods: </h4>
+               {% for pod in jenkinsPods %}
+                  <h4>{{ pod['name'] }}</h4>
                   <table class="table-bordered" id="{{ workloadName }}">
                      <tr>
                         <td>

--- a/build/templates/reportTemplate.html.j2
+++ b/build/templates/reportTemplate.html.j2
@@ -82,6 +82,18 @@
             </div>
             <hr/>
             <h3>Details</h3>
+            {% if jenkinsPods|length > 0 %}
+               <h4>Jenkins Pods</h4>
+                It looks like one or more Jenkins instances has been found in your tools namespace. <strong>Use of Jenkins is highly discouraged on the Platform due to
+                its high resource consumption.</strong> Please consider switching to other modern and more secure 
+                <a href="https://developer.gov.bc.ca/CICD-with-Pipeline-Automation" target="_blank">automation technologies available on the
+               Platform..</a>
+               <p/><p/>
+               Pods: 
+               {% for pod in   jenkinsPods %}
+                  {{ pod }}
+               {% endfor %}
+            {% endif %}
             <div id="imagestream-info">
                <h4>Imagestreams</h4>
                There {{ 'is' if imagestreams|length == 1 else 'are'}} {{ imagestreams|length }} 

--- a/build/templates/reportTemplate.html.j2
+++ b/build/templates/reportTemplate.html.j2
@@ -90,11 +90,55 @@
                   <a href="https://developer.gov.bc.ca/CICD-with-Pipeline-Automation" target="_blank">automation technologies available on the
                   Platform..</a>
                   <p/><p/>
-                  Pods: 
-                  {% for pod in   jenkinsPods %}
-                     {{ pod }}
-                  {% endfor %}
                </div>
+               Pods: 
+               {% for pod in   jenkinsPods %}
+                  <h4>Pod: {{ pod['name'] }}</h4>
+                  <table class="table-bordered" id="{{ workloadName }}">
+                     <tr>
+                        <td>
+                           Limits
+                        </td>
+                     </tr>
+                     <tr>
+                        <td>
+                           CPU 
+                        </td>
+                        <td>
+                           {{ pod['cpuLimit'] }}
+                        </td>
+                     </tr>
+                     <tr>
+                        <td>
+                           memory 
+                        </td>
+                        <td>
+                           {{ pod['memoryLimit'] }}
+                        </td>
+                     </tr>
+                     <tr>
+                        <td>
+                           Requests
+                        </td>
+                     </tr>
+                     <tr>
+                        <td>
+                           CPU 
+                        </td>
+                        <td>
+                           {{ pod['cpuRequest'] }}
+                        </td>
+                     </tr>
+                     <tr>
+                        <td>
+                           memory 
+                        </td>
+                        <td>
+                           {{ pod['memoryRequest'] }}
+                        </td>
+                     </tr>
+                  </table>
+               {% endfor %}
             {% endif %}
             <div id="imagestream-info">
                <h4>Imagestreams</h4>

--- a/build/templates/reportTemplate.html.j2
+++ b/build/templates/reportTemplate.html.j2
@@ -97,6 +97,20 @@
                   <table class="table-bordered" id="{{ workloadName }}">
                      <tr>
                         <td>
+                           Config point
+                        </td>
+                        <td>
+                           Allocation
+                        </td>
+                        <td>
+                           Recommended
+                        </td>
+                        <td>
+                           Meets best pratices?
+                        </td>
+                     </tr>
+                     <tr>
+                        <td>
                            Limits
                         </td>
                      </tr>
@@ -107,6 +121,22 @@
                         <td>
                            {{ pod['cpuLimit'] }}
                         </td>
+                        <td>
+                           1000m
+                        </td>
+                        <td>
+                        {% if pod['cpuLimitMeetsBP'] %}
+                           <div class="status-icon pass">
+                              &#10004
+                           </div>
+                           Yes
+                        {% else %}
+                           <div class="status-icon warning">
+                              !
+                           </div>
+                           No
+                        {% endif %}
+                        </td>
                      </tr>
                      <tr>
                         <td>
@@ -114,6 +144,22 @@
                         </td>
                         <td>
                            {{ pod['memoryLimit'] }}
+                        </td>
+                        <td>
+                           1-2Gi
+                        </td>
+                         <td>
+                        {% if pod['memLimitMeetsBP'] %}
+                           <div class="status-icon pass">
+                              &#10004
+                           </div>
+                           Yes
+                        {% else %}
+                           <div class="status-icon warning">
+                              !
+                           </div>
+                           No
+                        {% endif %}
                         </td>
                      </tr>
                      <tr>
@@ -128,6 +174,22 @@
                         <td>
                            {{ pod['cpuRequest'] }}
                         </td>
+                        <td>
+                           100m
+                        </td>
+                         <td>
+                        {% if pod['cpuReqMeetsBP'] %}
+                           <div class="status-icon pass">
+                              &#10004
+                           </div>
+                           Yes
+                        {% else %}
+                           <div class="status-icon warning">
+                              !
+                           </div>
+                           No
+                        {% endif %}
+                        </td>
                      </tr>
                      <tr>
                         <td>
@@ -135,6 +197,22 @@
                         </td>
                         <td>
                            {{ pod['memoryRequest'] }}
+                        </td>
+                        <td>
+                           512Mi
+                        </td>
+                         <td>
+                        {% if pod['memReqMeetsBP'] %}
+                           <div class="status-icon pass">
+                              &#10004
+                           </div>
+                           Yes
+                        {% else %}
+                           <div class="status-icon warning">
+                              !
+                           </div>
+                           No
+                        {% endif %}
                         </td>
                      </tr>
                   </table>


### PR DESCRIPTION
Jenkins can be used as a deployment pipeline (or so I gather) in OpenShift, but we don't like it because of its high resource consumption, and it is not as secure as more modern approaches. 
So we've added a check that if the namespace that the report is being run on is a tools namespace, we see if any of those pods are Jenkins pods, and whether or not the Limit and Request settings for CPU and Memory match our best practices. 
Then on the report output itself, we have scary red text saying jenkins in bad, and nicer black text saying where to learn more, as well as a table showing which bits meet best practices or not. 
![image](https://user-images.githubusercontent.com/4934684/152434640-960500a5-69d7-45a6-a34c-7517288bcc8d.png)
