### PR TITLE
Computing imagestream size

### DIFF
--- a/build/report.py
+++ b/build/report.py
@@ -69,7 +69,6 @@ def getImageStreamSize(namespace='default'):
   # Loop through the ImageStreamTags
     # Initialize a dictionary of layers for this ImageStreamTag
     # If the image has no tags, break out
-  images = []
   tagLayers = {}
   for imagestream in imagestreams['items']:
     name = imagestream['metadata']['name']
@@ -77,27 +76,16 @@ def getImageStreamSize(namespace='default'):
 
     for tag in imagestream['status']['tags']:
       for item in tag['items']:
-        images.append(item['image'])
         image = item['image']
         imagestreamImages = (json.loads(oc('get', f'--raw=/apis/image.openshift.io/v1/namespaces/{namespace}/imagestreamimages/{name}@{image}')))
-        print(imagestreamImages['image']['dockerImageMetadata']['Size'])
-        print(str(image) + ': '  + str(float(imagestreamImages['image']['dockerImageMetadata']['Size'])/1000000))
         for dockerImageLayer in imagestreamImages['image']['dockerImageLayers']:
           tagLayers[dockerImageLayer['name']] = dockerImageLayer['size']
-    # for imagestreamTag in imagestream['status']['tags']:
-    #   for imagestreamTagItem in imagestreamTag['items']:
-    #     image = imagestreamTagItem['image']
-    #     imagestreamImages = json.loads(oc('get', f'--raw=/apis/image.openshift.io/v1/namespaces/{namespace}/imagestreamimages/{name}@{image}'))
 
-    #     for imageLayer in imagestreamImages['image']['dockerImageMetadata']:
-    #        print (imageLayer)
-        #   totalSize += float(imageLayer['size'])
   for tagLayer in tagLayers.values():
     totalSize +=  float(tagLayer)
     
   logging.info('TOTAL IMAGESTREAM SIZE: ' + str(totalSize / 1000000) + ' MB.')
   return totalSize
-
 #end
 
 def hpaCheck(workloadData):

--- a/build/report.py
+++ b/build/report.py
@@ -56,10 +56,7 @@ def getObjects(type, namespace='default'):
 def getImageStreamSize(namespace='default'):
   totalSize = 0
   oc = local["oc"]
-  #imagestreams for this namespace
-  #$(oc -n ${NS} get ImageStreams -o=custom-columns=NAME:.metadata.name --no-headers)
   imagestreams = json.loads(oc('get', 'imagestreams', '-n', namespace, '-o', 'json'))
-  #imagestreams = json.loads(oc('get' f'--raw=/apis/image.openshift.io/v1/namespaces/{namespace}/imagestreams/${IMAGESTREAM}'))
   logging.info("Number of image streams: " + str(len(imagestreams['items'])))
 
 # Loop through the ImageStreams
@@ -69,7 +66,7 @@ def getImageStreamSize(namespace='default'):
   # Loop through the ImageStreamTags
     # Initialize a dictionary of layers for this ImageStreamTag
     # If the image has no tags, break out
-  tagLayers = {}
+  imageLayers = {}
   for imagestream in imagestreams['items']:
     name = imagestream['metadata']['name']
     imagestream = json.loads(oc('get', f'--raw=/apis/image.openshift.io/v1/namespaces/{namespace}/imagestreams/{name}'))
@@ -79,10 +76,10 @@ def getImageStreamSize(namespace='default'):
         image = item['image']
         imagestreamImages = (json.loads(oc('get', f'--raw=/apis/image.openshift.io/v1/namespaces/{namespace}/imagestreamimages/{name}@{image}')))
         for dockerImageLayer in imagestreamImages['image']['dockerImageLayers']:
-          tagLayers[dockerImageLayer['name']] = dockerImageLayer['size']
+          imageLayers[dockerImageLayer['name']] = dockerImageLayer['size']
 
-  for tagLayer in tagLayers.values():
-    totalSize +=  float(tagLayer)
+  for imageLayerSize in imageLayers.values():
+    totalSize +=  float(imageLayerSize)
     
   logging.info('TOTAL IMAGESTREAM SIZE: ' + str(totalSize / 1000000) + ' MB.')
   return totalSize


### PR DESCRIPTION
Context: When people install applications in OpenShift, they stream a docker file image. One problem that has come up a few times is that clients overpopulate namespaces with redundant imagestreams when they upgrade an application, (I guess, I'm not totally sure).  
I've added a check  to count how many imagestreams are used in a namespace, and how much space they  use up based on Steve Barres code: https://github.com/bcgov/how-to-workshops/blob/master/image-registry/registry-usage.sh.
There is a much more direct way of calculating this, but it requires the user to have some pretty darn elevated privileges that go beyond just being an admin for the namespace. I know. I don't get it either. 
So based on Steve's example, we are doing is looping through each imagestream in the namespace, finding all the tag items, the tag items have dockerImageLayers, and we make a dictionary of their names and sizes because there's some redundancy and if we just tally it all up on the spot, the sum is too high. 